### PR TITLE
CI changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ cache:
 
 install:
   - rustup component add rustfmt-preview
-  - cargo install clippy
+  - cargo install clippy --force
 
 script:
   - cargo fmt --all -- --check

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,21 @@
 sudo: false
+
 language: rust
-rust: stable
+rust: nightly
+
 os:
   - osx
   - linux
+
 cache:
   cargo: true
 
+install:
+  - rustup component add rustfmt-preview
+  - cargo install clippy
+
 script:
+  - cargo fmt --all -- --check
+  - cargo clippy
   - cargo build
   - cargo test

--- a/src/packet/types/key.rs
+++ b/src/packet/types/key.rs
@@ -309,7 +309,7 @@ macro_rules! key {
                                 packet.extend(bignum_to_mpi(p));
                                 //a one-octet size of the following fields
                                 packet.push(3); // Always 3??
-                                //a one-octet value 01
+                                                //a one-octet value 01
                                 packet.push(1);
                                 //a one-octet hash function ID used with a KDF
                                 packet.push(*hash);
@@ -373,7 +373,7 @@ macro_rules! key {
                                 packet.extend(bignum_to_mpi(p));
                                 //a one-octet size of the following fields
                                 packet.push(3); // Always 3??
-                                //a one-octet value 01
+                                                //a one-octet value 01
                                 packet.push(1);
                                 //a one-octet hash function ID used with a KDF
                                 packet.push(*hash);


### PR DESCRIPTION
- Switch to Nightly
- Added cargo clippy
- Added rustfmt check - only passes if rustfmt was ran in commit

Switching to Nightly shouldn't be an issue as a nightly build passing means a stable build will pass.