### PR TITLE
Some Makefile voodoo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Cargo.lock
 .profile
 ios_simulator_app
 *.h
+pgp-ffi/build-stamp

--- a/pgp-ffi/Makefile
+++ b/pgp-ffi/Makefile
@@ -30,20 +30,26 @@ endif
 
 soext := $(pgp_lib_extension)
 
-all: clean build install
+CARGO_SRC := $(CURDIR)/../Cargo.toml $(CURDIR)/../Cargo.lock
+RUST_SRC := $(shell find $(CURDIR)/.. -name '*.rs')
+LOCAL_SRC := build.rs librpgp.h
 
-build:
-	cd ../ && cargo test --release -p pgp-ffi && cargo build --release -p pgp-ffi && cd pgp-ffi
+all: build
+
+build: build-stamp
+build-stamp: $(LOCAL_SRC) $(CARGO_SRC) $(RUST_SRC)
+	cd $(CURDIR)/../ && cargo test --release -p pgp-ffi && cargo build --release -p pgp-ffi && cd pgp-ffi
+	touch $@
 
 install: build
 	install -d $(DESTDIR)$(PREFIX)/lib/
-	install -m 644 ../target/release/libpgp_ffi$(soext) $(DESTDIR)$(PREFIX)/lib/librpgp$(soext)
+	install -m 644 $(CURDIR)/../target/release/libpgp_ffi$(soext) $(DESTDIR)$(PREFIX)/lib/librpgp$(soext)
 	install -d $(DESTDIR)$(PREFIX)/include/
 	install -m 644 librpgp.h $(DESTDIR)$(PREFIX)/include/
 	install -d $(DESTDIR)$(PREFIX)/lib/pkconfig
-	install -m 644 ../target/release/pkgconfig/rpgp.pc $(DESTDIR)$(PREFIX)/lib/pkgconfig
+	install -m 644 $(CURDIR)/../target/release/pkgconfig/rpgp.pc $(DESTDIR)$(PREFIX)/lib/pkgconfig
 
 clean:
-	rm -f libpgp.h
+	rm -f librpgp.h
 
 .PHONY: clean build install

--- a/pgp-ffi/rpgp.pc.in
+++ b/pgp-ffi/rpgp.pc.in
@@ -7,5 +7,5 @@ Description: {description}
 URL: {url}
 Version: {version}
 Cflags: -I${{includedir}}
-Libs: -L${{libdir}} -lpgp
+Libs: -L${{libdir}} -lrpgp
 Libs.private: {libs_priv}


### PR DESCRIPTION
This attempts to make the usual `make; make install` work.  In particular
it means people can invoke make install as sudo without having to worry
needing rust/cargo installed for the root user.

It needs to have a stab at knowing what the input files are sadly, and
also needs to create a single output; hence the, somewhat traditional,
build-stamp file.

It also uses some $(CURDIR) fun to so that `make -C pgp-ffi` will work
fine as well.

Lastly it fixes the librpgp.h typo and -lrpgp in the pkg-config file.