### PR TITLE
Do not depend on generated files, clean the stamp file

### DIFF
--- a/pgp-ffi/Makefile
+++ b/pgp-ffi/Makefile
@@ -30,15 +30,15 @@ endif
 
 soext := $(pgp_lib_extension)
 
-CARGO_SRC := $(CURDIR)/../Cargo.toml $(CURDIR)/../Cargo.lock
+CARGO_SRC := $(CURDIR)/../Cargo.toml
 RUST_SRC := $(shell find $(CURDIR)/.. -name '*.rs')
-LOCAL_SRC := build.rs librpgp.h
+LOCAL_SRC := build.rs
 
 all: build
 
 build: build-stamp
 build-stamp: $(LOCAL_SRC) $(CARGO_SRC) $(RUST_SRC)
-	cd $(CURDIR)/../ && cargo test --release -p pgp-ffi && cargo build --release --features nightly -p pgp-ffi && cd pgp-ffi
+	cd $(CURDIR)/../ && cargo test --release -p pgp-ffi && cargo build --release --features nightly -p pgp-ffi
 	touch $@
 
 install: build
@@ -51,5 +51,6 @@ install: build
 
 clean:
 	rm -f librpgp.h
+	rm -f build-stamp
 
 .PHONY: clean build install


### PR DESCRIPTION
While I didn't realise Cargo.toml was generated I should really have
known better for the .h file.  Oh well.

Also obviously the -stamp file needs to be removed on clean.